### PR TITLE
fix:add stdint.h for uint64_t....

### DIFF
--- a/pcs.h
+++ b/pcs.h
@@ -5,10 +5,12 @@
 #ifndef _BAIDU_PCS_H
 #define _BAIDU_PCS_H
 
-#include "http_client.h"
-#include "cJSON.h"
+#include <stdint.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+
+#include "http_client.h"
+#include "cJSON.h"
 
 /* 文件切片 */
 typedef struct PCSFileBlock_s PCSFileBlock;


### PR DESCRIPTION
我的环境是这样的:
gcc version 4.8.2 (Ubuntu 4.8.2-19ubuntu1)

需要加stdint.h才能编译通过。
